### PR TITLE
Blocking socket and error checking

### DIFF
--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -25,18 +25,10 @@ void add_socket_write(struct io_uring *ring, int fd, __u16 bid, size_t size, uns
 void add_provide_buf(struct io_uring *ring, __u16 bid, unsigned gid);
 
 enum {
-    ACCEPT = 1,
-    READ = 2,
-    WRITE = 3,
-    PROV_BUF = 4,
-};
-
-char* OPS_NAMES[] = {
-        "UNKNOWN",
-        "ACCEPT",
-        "READ",
-        "WRITE",
-        "PROV_BUF",
+    ACCEPT,
+    READ,
+    WRITE,
+    PROV_BUF,
 };
 
 typedef struct conn_info {

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
     socklen_t client_len = sizeof(client_addr);
 
     // setup socket
-    int sock_listen_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    int sock_listen_fd = socket(AF_INET, SOCK_STREAM, 0);
     const int val = 1;
     setsockopt(sock_listen_fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val));
 

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -45,7 +45,7 @@ typedef struct conn_info {
     __u16 bid;
 } conn_info;
 
-char bufs[MAX_CONNECTIONS][MAX_MESSAGE_LEN];
+char bufs[BUFFERS_COUNT][MAX_MESSAGE_LEN] = {0};
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {
@@ -105,7 +105,6 @@ int main(int argc, char *argv[]) {
     free(probe);
 
     // register buffers for buffer selection
-    unsigned buf_amount = 1000;
     unsigned group_id = 1337;
     struct io_uring_sqe *sqe;
     struct io_uring_cqe *cqe;

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -149,8 +149,6 @@ int main(int argc, char *argv[]) {
                 int sock_conn_fd = cqe->res;
                 if (sock_conn_fd >= 0) {
                     add_socket_read(&ring, sock_conn_fd, group_id, MAX_MESSAGE_LEN, IOSQE_BUFFER_SELECT);
-                } else if (cqe->res < 0 && cqe->res != -EAGAIN) {
-                    exit(3);
                 }
 
                 // new connected client; read data from socket and re-add accept to monitor for new connections
@@ -166,10 +164,6 @@ int main(int argc, char *argv[]) {
                     add_socket_write(&ring, conn_i.fd, bid, bytes_read, 0);
                 }
             } else if (type == WRITE) {
-                if (cqe->res < 0) {
-                    exit(4);
-                }
-
                 add_provide_buf(&ring, conn_i.bid, group_id);
                 add_socket_read(&ring, conn_i.fd, group_id, MAX_MESSAGE_LEN, IOSQE_BUFFER_SELECT);
             }

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -228,7 +228,7 @@ void add_provide_buf(struct io_uring *ring, __u16 bid, unsigned gid) {
     io_uring_prep_provide_buffers(sqe, bufs[bid], MAX_MESSAGE_LEN, 1, gid, bid);
 
     conn_info conn_i = {
-        .fd = NULL,
+        .fd = 0,
         .type = PROV_BUF,
     };
     memcpy(&sqe->user_data, &conn_i, sizeof(conn_i));

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -153,9 +153,13 @@ int main(int argc, char *argv[]) {
                 }
             } else if (type == ACCEPT) {
                 int sock_conn_fd = cqe->res;
+                if (sock_conn_fd >= 0) {
+                    add_socket_read(&ring, sock_conn_fd, group_id, MAX_MESSAGE_LEN, IOSQE_BUFFER_SELECT);
+                } else if (cqe->res < 0 && cqe->res != -EAGAIN) {
+                    exit(3);
+                }
 
                 // new connected client; read data from socket and re-add accept to monitor for new connections
-                add_socket_read(&ring, sock_conn_fd, group_id, MAX_MESSAGE_LEN, IOSQE_BUFFER_SELECT);
                 add_accept(&ring, sock_listen_fd, (struct sockaddr *)&client_addr, &client_len, 0);
             } else if (type == READ) {
                 int bytes_read = cqe->res;

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -22,10 +22,18 @@ void add_socket_write(struct io_uring *ring, int fd, __u16 bid, size_t size, uns
 void add_provide_buf(struct io_uring *ring, __u16 bid, unsigned gid);
 
 enum {
-    ACCEPT,
-    READ,
-    WRITE,
-    PROV_BUF,
+    ACCEPT = 1,
+    READ = 2,
+    WRITE = 3,
+    PROV_BUF = 4,
+};
+
+char* OPS_NAMES[] = {
+        "UNKNOWN",
+        "ACCEPT",
+        "READ",
+        "WRITE",
+        "PROV_BUF",
 };
 
 typedef struct conn_info {

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -143,7 +143,8 @@ int main(int argc, char *argv[]) {
                 exit(1);
             } else if (type == PROV_BUF) {
                 if (cqe->res < 0) {
-                    exit(2);
+                    printf("cqe->res = %d\n", cqe->res);
+                    exit(1);
                 }
             } else if (type == ACCEPT) {
                 int sock_conn_fd = cqe->res;

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -11,9 +11,12 @@
 
 #include "liburing.h"
 
-#define MAX_CONNECTIONS 4096
-#define BACKLOG 512
-#define MAX_MESSAGE_LEN 2048
+#define MAX_CONNECTIONS     4096
+#define BACKLOG             512
+#define MAX_MESSAGE_LEN     2048
+
+#define BUFFERS_COUNT       MAX_CONNECTIONS
+
 #define IORING_FEAT_FAST_POLL (1U << 5)
 
 void add_accept(struct io_uring *ring, int fd, struct sockaddr *client_addr, socklen_t *client_len, unsigned flags);
@@ -108,7 +111,7 @@ int main(int argc, char *argv[]) {
     struct io_uring_cqe *cqe;
 
     sqe = io_uring_get_sqe(&ring);
-    io_uring_prep_provide_buffers(sqe, bufs, MAX_MESSAGE_LEN, buf_amount, group_id, 0);
+    io_uring_prep_provide_buffers(sqe, bufs, MAX_MESSAGE_LEN, BUFFERS_COUNT, group_id, 0);
 
     io_uring_submit(&ring);
     io_uring_wait_cqe(&ring, &cqe);

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -136,12 +136,6 @@ int main(int argc, char *argv[]) {
             struct conn_info conn_i;
             memcpy(&conn_i, &cqe->user_data, sizeof(conn_i));
 
-            if (cqe->res != -EAGAIN && cqe->res != -ECONNRESET && cqe->res < 0) {
-                fprintf(stdout, "[CQE][%s] cqe->res = %d, cqe->flags >> 16 = %d, cqe->flags >> 16 = %d\n",
-                        OPS_NAMES[conn_i.type], cqe->res, cqe->flags >> 16, cqe->flags & 0xFFFF);
-                fflush(stdout);
-            }
-
             int type = conn_i.type;
             if (cqe->res == -ENOBUFS) {
                 fprintf(stdout, "bufs in automatic buffer selection empty, this should not happen...\n");

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -137,6 +137,12 @@ int main(int argc, char *argv[]) {
             struct conn_info conn_i;
             memcpy(&conn_i, &cqe->user_data, sizeof(conn_i));
 
+            if (cqe->res != -EAGAIN && cqe->res != -ECONNRESET && cqe->res < 0) {
+                fprintf(stdout, "[CQE][%s] cqe->res = %d, cqe->flags >> 16 = %d, cqe->flags >> 16 = %d\n",
+                        OPS_NAMES[conn_i.type], cqe->res, cqe->flags >> 16, cqe->flags & 0xFFFF);
+                fflush(stdout);
+            }
+
             int type = conn_i.type;
             if (cqe->res == -ENOBUFS) {
                 printf("bufs in automatic buffer selection empty, this should not happen...\n");

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -46,6 +46,7 @@ typedef struct conn_info {
 } conn_info;
 
 char bufs[BUFFERS_COUNT][MAX_MESSAGE_LEN] = {0};
+int group_id = 1337;
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {
@@ -105,7 +106,6 @@ int main(int argc, char *argv[]) {
     free(probe);
 
     // register buffers for buffer selection
-    unsigned group_id = 1337;
     struct io_uring_sqe *sqe;
     struct io_uring_cqe *cqe;
 

--- a/io_uring_echo_server.c
+++ b/io_uring_echo_server.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
     struct io_uring ring;
     memset(&params, 0, sizeof(params));
 
-    if (io_uring_queue_init_params(1024, &ring, &params) < 0) {
+    if (io_uring_queue_init_params(2048, &ring, &params) < 0) {
         perror("io_uring_init_failed...\n");
         exit(1);
     }


### PR DESCRIPTION
This PR contains a number of changes with the purpose of:
- improve the error checking
- stop submitting reads on accepts for fds that are errors, because the socket is initialized with the SOCK_NONBLOCK the OS responds that there are no new connections incoming and to try again with EGAIN
- drop the SOCK_NONBLOCK, in the real world the server may want to do something else and may need to use it or it may use threads / worker processes where it wouldn't use it so for the bench it would be better to drop it; in comparison with the current implementation every loop leads to 2 additional CQEs, 1 for a new listen and 1 for the read for the EGAIN error
- use a const to define the amount of buffers to allocate and move the group id outside the main (as parameter)
- increase the queue size to 2048 (worst case scenario 1 CQE is needed for a listen, 1000 for reads, 1000 for provide bufs)

I didn't face any hang, I was able to perform all the tests straight from 1 single instance running properly all the time, I wonder if these issues were a combination of the small queue size and the listen/reads because of the non blocking server socket.